### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-validation.yml
+++ b/.github/workflows/build-validation.yml
@@ -1,5 +1,8 @@
 name: Build Validation
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/avwolferen/blog/security/code-scanning/9](https://github.com/avwolferen/blog/security/code-scanning/9)

In general, the fix is to add an explicit `permissions` block that grants only the scopes needed for this workflow. This job checks out code, installs dependencies, runs lint/type-check/build, uses the cache action, and uploads artifacts. None of these require write access to repository contents or privileged scopes like `issues`, `pull-requests`, or `actions`. Therefore, an appropriate minimal permission is `contents: read` (and, if desired, you could omit even that when not needed, but `actions/checkout` with `persist-credentials: false` still works fine with `contents: read`).

The best fix with minimal behavioral change is to add a `permissions` block at the workflow root level (so it applies to all jobs) directly under `name:` or `on:`, specifying `contents: read`. This will limit the `GITHUB_TOKEN` while preserving all existing functionality. Concretely, in `.github/workflows/build-validation.yml`, insert:

```yaml
permissions:
  contents: read
```

near the top of the file (e.g., after `name: Build Validation`). No additional methods, imports, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
